### PR TITLE
Adding a default search provider option, with DuckDuckGo as the default

### DIFF
--- a/client/src/components/Settings/OtherSettings/OtherSettings.tsx
+++ b/client/src/components/Settings/OtherSettings/OtherSettings.tsx
@@ -35,6 +35,7 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
     hideApps: 0,
     hideCategories: 0,
     hideSearch: 0,
+    defaultSearchProvider: 'd',
     useOrdering: 'createdAt',
     appsSameTab: 0,
     bookmarksSameTab: 0,
@@ -51,6 +52,7 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
       hideApps: searchConfig('hideApps', 0),
       hideCategories: searchConfig('hideCategories', 0),
       hideSearch: searchConfig('hideSearch', 0),
+      defaultSearchProvider: searchConfig('defaultSearchProvider', 'd'),
       useOrdering: searchConfig('useOrdering', 'createdAt'),
       appsSameTab: searchConfig('appsSameTab', 0),
       bookmarksSameTab: searchConfig('bookmarksSameTab', 0),
@@ -190,6 +192,24 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
         >
           <option value={1}>True</option>
           <option value={0}>False</option>
+        </select>
+      </InputGroup>
+      <InputGroup>
+        <label htmlFor='defaultSearchProvider'>Default Search Provider</label>
+        <select
+          id='defaultSearchProvider'
+          name='defaultSearchProvider'
+          value={formData.defaultSearchProvider}
+          onChange={(e) => inputChangeHandler(e)}
+        >
+          <option value='d'>DuckDuckGo</option>
+          <option value='g'>Google</option>
+          <option value='s'>Disroot</option>
+          <option value='yt'>YouTube</option>
+          <option value='r'>Reddit</option>
+          <option value='im'>IMDb</option>
+          <option value='mv'>The Movie Database</option>
+          <option value='sp'>Spotify</option>
         </select>
       </InputGroup>
       <InputGroup>

--- a/client/src/interfaces/Forms.ts
+++ b/client/src/interfaces/Forms.ts
@@ -13,6 +13,7 @@ export interface SettingsForm {
   hideApps: number;
   hideCategories: number;
   hideSearch: number;
+  defaultSearchProvider: string;
   useOrdering: string;
   appsSameTab: number;
   bookmarksSameTab: number;

--- a/client/src/utility/searchParser.ts
+++ b/client/src/utility/searchParser.ts
@@ -4,12 +4,13 @@ import { Query } from '../interfaces';
 import { searchConfig } from '.';
 
 export const searchParser = (searchQuery: string): boolean => {
-  const space = searchQuery.indexOf(' ');
-  const prefix = searchQuery.slice(1, space);
-  const search = encodeURIComponent(searchQuery.slice(space + 1));
+  const splitQuery = searchQuery.match(/^\/([a-z]+)[ ](.+)$/i);
+  const prefix = splitQuery ? splitQuery[1] : searchConfig('defaultSearchProvider', 'd');
+  const search = splitQuery ? encodeURIComponent(splitQuery[2]) : encodeURIComponent(searchQuery);
 
   const query = queries.find((q: Query) => q.prefix === prefix);
 
+  console.log("QUERY IS  " + query);
   if (query) {
     const sameTab = searchConfig('searchSameTab', false);
 

--- a/utils/initialConfig.json
+++ b/utils/initialConfig.json
@@ -59,6 +59,10 @@
     {
       "key": "hideSearch",
       "value": false
+    },
+    {
+      "key": "defaultSearchProvider",
+      "value": "d"
     }
   ]
 }


### PR DESCRIPTION
Rather than having to type the search prefix of "/d" or "/g" (or whatever) for each search, I figured that a default was in order. I chose DuckDuckGo as the default search provider to reduce any privacy concerns.

Now, if you don't type a search prefix, DuckDuckGo (or your preferred default) is used.