### PR TITLE
Use correct changelog link

### DIFF
--- a/client/src/components/Settings/AppDetails/AppDetails.tsx
+++ b/client/src/components/Settings/AppDetails/AppDetails.tsx
@@ -20,7 +20,7 @@ const AppDetails = (): JSX.Element => {
       <p className={classes.AppVersion}>
         See changelog {' '}
         <a
-          href='https://github.com/pawelmalak/flame/CHANGELOG.md'
+          href='https://github.com/pawelmalak/flame/blob/master/CHANGELOG.md'
           target='_blank'
           rel='noreferrer'>
           here


### PR DESCRIPTION
current link in release 1.6.1 points to an incorrect url that returns 404