### PR TITLE
Added Docker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ services:
     container_name: flame
     volumes:
       - <host_dir>:/app/data
-      - /var/run/docker.sock:/var/sock/docker.sock # Docker socket
+      - /var/run/docker.sock:/var/sock/docker.sock # optional but required for Docker integration feature
     ports:
       - 5005:5005
     restart: unless-stopped

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ services:
     container_name: flame
     volumes:
       - <host_dir>:/app/data
+      - /var/run/docker.sock:/var/sock/docker.sock # Docker socket
     ports:
       - 5005:5005
     restart: unless-stopped
@@ -154,6 +155,20 @@ To use search bar you need to type your search query with selected prefix. For e
 - URL without protocol
   - Format: `www.domain.com`, `domain.com`, `sub.domain.com`, `local`, `ip`, `ip:port`
   - Redirect: `http://{dest}`
+
+### Docker integration
+
+In order to use the Docker integration, each container must have the following labels:
+
+```yml
+labels:
+  - flame.type=application # "app" works too
+  - flame.name=My container
+  - flame.url=https://example.com
+  - flame.icon=icon-name # Optional, default is "docker"
+```
+
+And you must have activated the Docker sync option in the settings panel.
 
 ### Custom CSS
 

--- a/client/src/components/Settings/OtherSettings/OtherSettings.tsx
+++ b/client/src/components/Settings/OtherSettings/OtherSettings.tsx
@@ -40,7 +40,9 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
     useOrdering: 'createdAt',
     appsSameTab: 0,
     bookmarksSameTab: 0,
-    searchSameTab: 0
+    searchSameTab: 0,
+    dockerApps:1,
+    unpinStoppedApps: 1
   })
 
   // Get config
@@ -57,7 +59,9 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
       useOrdering: searchConfig('useOrdering', 'createdAt'),
       appsSameTab: searchConfig('appsSameTab', 0),
       bookmarksSameTab: searchConfig('bookmarksSameTab', 0),
-      searchSameTab: searchConfig('searchSameTab', 0)
+      searchSameTab: searchConfig('searchSameTab', 0),
+      dockerApps: searchConfig('dockerApps', 1),
+      unpinStoppedApps: searchConfig('unpinStoppedApps', 1)
     })
   }, [props.loading]);
 
@@ -237,6 +241,31 @@ const OtherSettings = (props: ComponentProps): JSX.Element => {
           id='hideCategories'
           name='hideCategories'
           value={formData.hideCategories}
+          onChange={(e) => inputChangeHandler(e, true)}
+        >
+          <option value={1}>True</option>
+          <option value={0}>False</option>
+        </select>
+      </InputGroup>
+      <h2 className={classes.SettingsSection}>Docker</h2>
+      <InputGroup>
+        <label htmlFor='dockerApps'>Use Docker API</label>
+        <select
+          id='dockerApps'
+          name='dockerApps'
+          value={formData.dockerApps}
+          onChange={(e) => inputChangeHandler(e, true)}
+        >
+          <option value={1}>True</option>
+          <option value={0}>False</option>
+        </select>
+      </InputGroup>
+      <InputGroup>
+        <label htmlFor='unpinStoppedApps'>Unpin stopped containers / other apps</label>
+        <select
+          id='unpinStoppedApps'
+          name='unpinStoppedApps'
+          value={formData.unpinStoppedApps}
           onChange={(e) => inputChangeHandler(e, true)}
         >
           <option value={1}>True</option>

--- a/client/src/interfaces/Forms.ts
+++ b/client/src/interfaces/Forms.ts
@@ -18,4 +18,6 @@ export interface SettingsForm {
   appsSameTab: number;
   bookmarksSameTab: number;
   searchSameTab: number;
+  dockerApps: number;
+  unpinStoppedApps: number;
 }

--- a/utils/initialConfig.json
+++ b/utils/initialConfig.json
@@ -63,6 +63,14 @@
     {
       "key": "defaultSearchProvider",
       "value": "d"
+    },
+    {
+      "key": "dockerApps",
+      "value": true
+    },
+    {
+      "key": "unpinStoppedApps",
+      "value": true
     }
   ]
 }


### PR DESCRIPTION
Use docker-compose labels to populate Flame dashboard as described in #14.
When the client fetch `/api/apps`, the server calls the docker socket and manage the apps in the dashboard.

I've never use Typescript before, so maybe it can be done in a better way rather inside the `getApps` function.