### PR TITLE
Add custom icon and multiple apps support to Docker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ labels:
   - flame.name=My container
   - flame.url=https://example.com
   - flame.icon=icon-name # Optional, default is "docker"
+# - flame.icon=custom to make changes in app. ie: custom icon upload
+```
+
+You can set up different apps in the same label adding `;` between each one.
+
+```yml
+labels:
+  - flame.type=application
+  - flame.name=First App;Second App
+  - flame.url=https://example1.com;https://example2.com
+  - flame.icon=icon-name1;icon-name2
 ```
 
 And you must have activated the Docker sync option in the settings panel.


### PR DESCRIPTION
Added custom icon option to docker-compose labels.
The icon has to be selected manually if the option is enabled.

Added multiple flame apps support to docker-compose separating each one with `;`.
If there are more issues about this I will make something like #90  proposes.

Also, updated the `README` to document this options.