### PR TITLE
Don't override user selected icon of a docker app

### DIFF
--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -120,7 +120,7 @@ exports.getApps = asyncWrapper(async (req, res, next) => {
         if (apps.some((app) => app.name === item.name)) {
           const app = apps.filter((e) => e.name === item.name)[0];
 
-          if (item.icon === 'custom') {
+          if (item.icon === 'custom' || app.icon != 'docker') {
             await app.update({
               name: item.name,
               url: item.url,


### PR DESCRIPTION
When user edits icon of a docker app then it will be overridden when docker app are refreshed. 
This fix presists the user selected icon if container has no explicit icon configured.