### PR TITLE
[Suggestions] Remove search auto focus

### DIFF
--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -23,10 +23,6 @@ const SearchBar = (props: ComponentProps): JSX.Element => {
 
   const inputRef = useRef<HTMLInputElement>(document.createElement('input'));
 
-  useEffect(() => {
-    inputRef.current.focus();
-  }, []);
-
   const searchHandler = (e: KeyboardEvent<HTMLInputElement>) => {
     const { isLocal, search, query, isURL, sameTab } = searchParser(
       inputRef.current.value


### PR DESCRIPTION
Major annoyance for mobile devices. Mostly tablets that have large keyboards in landscape. You're forced to dismiss the keyboard every time you load the page.

Alternative: Make auto focus an option in settings.