### PR TITLE
Update Dockerfile for smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine as builder
 
 RUN apk update && apk add --no-cache nano curl
 
@@ -17,6 +17,12 @@ RUN mkdir -p ./public ./data \
     && cd .. \
     && mv ./client/build/* ./public \
     && rm -rf ./client
+
+FROM node:14-alpine
+
+COPY --from=builder /app /app
+
+WORKDIR /app
 
 EXPOSE 5005
 

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine as builder
 
 RUN apk update && apk add --no-cache nano curl
 

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -20,6 +20,12 @@ RUN mkdir -p ./public ./data \
     && rm -rf ./client \
     && apk del build-dependencies
 
+FROM node:14-alpine
+
+COPY --from=builder /app /app
+
+WORKDIR /app
+
 EXPOSE 5005
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Size: before: 471.3 MB after: 185.8 MB
Multiarch test: https://github.com/ekremparlak/flame/actions/runs/1408402556
Multiarch test image: https://github.com/ekremparlak/flame/pkgs/container/flame
Multiarch build create the image same size as normal build so can be used for latest tag
I tested the image and it was working but you should check too. 