### PR TITLE
bugfix: local-search support CJK

### DIFF
--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -69,7 +69,8 @@ export const SearchBar = (props: Props): JSX.Element => {
     );
 
     if (isLocal) {
-      setLocalSearch(search);
+      // no additional encoding required for local search
+      setLocalSearch(inputRef.current.value);
     }
 
     if (e.code === 'Enter' || e.code === 'NumpadEnter') {


### PR DESCRIPTION
## Problem recurring

If the title of bookmark/app set by the user contains non-English characters such as CJK.

![image](https://user-images.githubusercontent.com/1500781/148013729-96588976-66b9-4988-abd4-944ee205ca67.png)

When users search, they will not get results.

![image](https://user-images.githubusercontent.com/1500781/148013810-5cb74050-11d5-4a4a-9c71-6197cac8f78c.png)


## Solution

When the user searches locally, the input content is not URL-encoded

![image](https://user-images.githubusercontent.com/1500781/148013781-6f62e711-a60d-4c40-948b-1ade888337a3.png)
