### PR TITLE
bugfix: sameTab does not work if prefix is localSearch

### DIFF
--- a/client/src/utility/searchParser.ts
+++ b/client/src/utility/searchParser.ts
@@ -41,9 +41,8 @@ export const searchParser = (searchQuery: string): SearchResult => {
 
     if (prefix === 'l') {
       result.isLocal = true;
-    } else {
-      result.sameTab = config.searchSameTab;
     }
+    result.sameTab = config.searchSameTab;
 
     return result;
   }


### PR DESCRIPTION
bug is described here: #270

sameTab search option should be set even if `prefix=='l'` (local search). Just unnecessary else option error.

very nice project, cheers