### PR TITLE
feat: rework kubernetes annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,15 +214,16 @@ curl http://${IP}:${PORT}/version
 
 ### Kubernetes integration
 
-In order to use the Kubernetes integration, each ingress must have the following annotations:
+In order to use the Kubernetes integration, configure the annotations on the ingress:
 
 ```yml
 metadata:
   annotations:
-  - flame.pawelmalak/type=application # "app" works too
-  - flame.pawelmalak/name=My container
-  - flame.pawelmalak/url=https://example.com
-  - flame.pawelmalak/icon=icon-name # optional, default is "kubernetes"
+  - flame.pawelmalak/enabled=true              # required
+  - flame.pawelmalak/type=application          # optional, defaults to application
+  - flame.pawelmalak/name=My container         # optional, defaults to ingress name
+  - flame.pawelmalak/url=https://example.com   # optional, defaults to ingress host or ingress tls host
+  - flame.pawelmalak/icon=icon-name            # optional, defaults to "kubernetes"
 ```
 
 > "Use Kubernetes Ingress API" option must be enabled for this to work. You can find it in Settings > Docker

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -35,7 +35,7 @@ const useKubernetes = async (apps) => {
       const annotations = ingress.metadata.annotations;
       const name = ingress.metadata.name;
       let url = "http://" + ingress.spec.rules[0].host;
-      if (ingress.spec.tls?.[0].hosts[0]) {
+      if (ingress.spec.tls?.[0].hosts?.[0]]) {
         url = "https://" + ingress.spec.tls[0].hosts[0];
       }
 

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -39,10 +39,7 @@ const useKubernetes = async (apps) => {
         url = "https://" + ingress.spec.tls[0].hosts[0];
       }
 
-      if (
-        'flame.pawelmalak/enabled' in annotations &&
-        /^app/.test(annotations['flame.pawelmalak/type'])
-      ) {
+      if ('flame.pawelmalak/enabled' in annotations) {
         kubernetesApps.push({
           name: annotations['flame.pawelmalak/name'] || name,
           url: annotations['flame.pawelmalak/url'] || url,

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -33,15 +33,19 @@ const useKubernetes = async (apps) => {
 
     for (const ingress of ingresses) {
       const annotations = ingress.metadata.annotations;
+      const name = ingress.metadata.name;
+      let url = "http://" + ingress.spec.rules[0].host;
+      if (ingress.spec.tls?.[0].hosts[0]) {
+        url = "https://" + ingress.spec.tls[0].hosts[0];
+      }
 
       if (
-        'flame.pawelmalak/name' in annotations &&
-        'flame.pawelmalak/url' in annotations &&
+        'flame.pawelmalak/enabled' in annotations &&
         /^app/.test(annotations['flame.pawelmalak/type'])
       ) {
         kubernetesApps.push({
-          name: annotations['flame.pawelmalak/name'],
-          url: annotations['flame.pawelmalak/url'],
+          name: annotations['flame.pawelmalak/name'] || name,
+          url: annotations['flame.pawelmalak/url'] || url,
           icon: annotations['flame.pawelmalak/icon'] || 'kubernetes',
         });
       }


### PR DESCRIPTION
New annotation: 

```
# Enables flame to watch ingress
flame.pawelmalak/enabled
```

Changed annotations:

```
# defaults to ingress .metadata.name
flame.pawelmalak/name 
#  defaults to first ingress host found or if first ingress tls host found it uses that instead
flame.pawelmalak/url
```

This is helpful in reducing the amount of annotations needed for a basic setup.

Before:

```yaml
annotations:
  - flame.pawelmalak/type=application # required
  - flame.pawelmalak/name=My container # required
  - flame.pawelmalak/url=https://example.com # required
  - flame.pawelmalak/icon=kubernetes # optional
```

After:

```yaml
annotations:
  - flame.pawelmalak/enabled=true # required
  - flame.pawelmalak/type=application # optional
  - flame.pawelmalak/name=My container # optional
  - flame.pawelmalak/url=https://example.com # optional
  - flame.pawelmalak/icon=kubernetes # optional
```

Closes: https://github.com/pawelmalak/flame/issues/290