### PR TITLE
fix: Update Permissions on Startup

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 5005
 ENV NODE_ENV=production
 ENV PASSWORD=flame_password
 
-CMD ["node", "server.js"]
+CMD ["sh", "-c", "chown -R node /app/data && node server.js"]

--- a/.docker/Dockerfile.multiarch
+++ b/.docker/Dockerfile.multiarch
@@ -28,4 +28,4 @@ EXPOSE 5005
 ENV NODE_ENV=production
 ENV PASSWORD=flame_password
 
-CMD ["node", "server.js"]
+CMD ["sh", "-c", "chown -R node /app/data && node server.js"]


### PR DESCRIPTION
This PR adds a command on container startup, to update file permissions of the persistent directory.
It is related to #308 & #309 and fixes the startup issues on exisiting instances.

Proposed integration workflow:

- Merge this PR and integrate it in one of the next feature releases to ensure that permissions are updated on exisiting instances
- Later merge #309 (maybe in version 3.0.0) because running the container in non-root mode unfortunately introduces a breaking change.

current instance => v2.3.0 to update permissions => (v2.x.x) => v3.0.0 running in non-root mode