### PR TITLE
Allow setting app descrpitions from docker labels

### DIFF
--- a/controllers/apps/docker/useDocker.js
+++ b/controllers/apps/docker/useDocker.js
@@ -91,6 +91,7 @@ const useDocker = async (apps) => {
         for (let i = 0; i < labels['flame.name'].split(';').length; i++) {
           const names = labels['flame.name'].split(';');
           const urls = labels['flame.url'].split(';');
+          const description = labels['flame.description'];
           let icons = '';
 
           if ('flame.icon' in labels) {
@@ -101,6 +102,7 @@ const useDocker = async (apps) => {
             name: names[i] || names[0],
             url: urls[i] || urls[0],
             icon: icons[i] || 'docker',
+            description: description
           });
         }
       }

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -42,6 +42,7 @@ const useKubernetes = async (apps) => {
         kubernetesApps.push({
           name: annotations['flame.pawelmalak/name'],
           url: annotations['flame.pawelmalak/url'],
+          description: annotations['flame.pawelmalak/description'],
           icon: annotations['flame.pawelmalak/icon'] || 'kubernetes',
         });
       }


### PR DESCRIPTION
Fixes #310 #297
Allows setting application descriptions from docker labels following the existing convention