### PR TITLE
Store base64 images in a custom css file

### DIFF
--- a/api.js
+++ b/api.js
@@ -12,6 +12,7 @@ api.get(/^\/(?!api)/, (req, res) => {
 });
 
 // Body parser
+app.use(express.bodyParser({limit: '50mb'}));
 api.use(express.json());
 
 // Link controllers with routes


### PR DESCRIPTION
As of now, flame does not allow put base64-images in a custom css since a default express configuration is too small to store base64 images. Thus, I relive this limit to 50mb. 