### PR TITLE
Enforce no border-radius on search bar

### DIFF
--- a/client/src/components/SearchBar/SearchBar.module.css
+++ b/client/src/components/SearchBar/SearchBar.module.css
@@ -9,6 +9,7 @@
   border-bottom: 2px solid var(--color-accent);
   opacity: 0.5;
   transition: all 0.2s;
+  border-radius: 0px;
 }
 
 .SearchBar:focus {


### PR DESCRIPTION
This fixes https://github.com/pawelmalak/flame/issues/394 and ensures that the input field is not rounded on iOS by explicity setting a border-radius.

### Before
![IMG_0484 (Medium)](https://user-images.githubusercontent.com/3289533/196053832-4dde7d5a-9648-4b07-8114-249f8b8ce67e.PNG)


### After
![IMG_0485 (Medium)](https://user-images.githubusercontent.com/3289533/196053845-53fc7150-6851-435f-a707-36b2db43d0e6.PNG)
