### PR TITLE
Custom docker socket (Issue #386 )

### DIFF
--- a/controllers/apps/docker/useDocker.js
+++ b/controllers/apps/docker/useDocker.js
@@ -20,7 +20,7 @@ const useDocker = async (apps) => {
       let { data } = await axios.get(
         `http://${host}/containers/json?{"status":["running"]}`,
         {
-          socketPath: '/var/run/docker.sock',
+          socketPath: process.env.DOCKER_SOCKET ? process.env.DOCKER_SOCKET : '/var/run/docker.sock',
         }
       );
 


### PR DESCRIPTION
Add the possibility to use the environment variable DOCKER_SOCKET to set the docker socket path.
Useful if not using the official docker engine to run the containers.

Original issue:
 https://github.com/pawelmalak/flame/issues/386