### PR TITLE
#452 - Adding support for Kubernetes Gateway API (such as HTTPRoute)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/client" # Location of package manifests
+    schedule:
+      interval: "weekly"
+

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -4,29 +4,56 @@ const Logger = require('../../../utils/Logger');
 const logger = new Logger();
 const loadConfig = require('../../../utils/loadConfig');
 
+
+const gatewayRoutes = [
+  { type: 'httproutes', version: 'v1' },
+  { type: 'tcproutes', version: 'v1alpha2' },
+   { type: 'grpcroutes', version: 'v1alpha2' },
+   { type: 'tlsroutes', version: 'v1alpha2' },
+   { type: 'udproutes', version: 'v1alpha2' }
+];
+
 const useKubernetes = async (apps) => {
   const { useOrdering: orderType, unpinStoppedApps } = await loadConfig();
 
   let ingresses = null;
+  let routeData = [];
 
   try {
     const kc = new k8s.KubeConfig();
     kc.loadFromCluster();
+
     const k8sNetworkingV1Api = kc.makeApiClient(k8s.NetworkingV1Api);
     await k8sNetworkingV1Api.listIngressForAllNamespaces().then((res) => {
       ingresses = res.body.items;
     });
+
+    const customObjectsApi = kc.makeApiClient(k8s.CustomObjectsApi);
+    for (let route of gatewayRoutes) {
+      await customObjectsApi.listClusterCustomObject('gateway.networking.k8s.io', route.version, route.type).then((res) => {
+        res.body.items.forEach(item => routeData.push({ ...item, routeType: route.type }));
+      }).catch(error => {
+        logger.log(`Error fetching ${route.type}: ${error.message}`, 'ERROR');
+      });
+    }
   } catch {
     logger.log("Can't connect to the Kubernetes API", 'ERROR');
+    logger.log(error.message, 'ERROR');
   }
 
-  if (ingresses) {
+  if (ingresses || routeData.length > 0) {
     apps = await App.findAll({
       order: [[orderType, 'ASC']],
     });
 
     ingresses = ingresses.filter(
       (e) => Object.keys(e.metadata.annotations).length !== 0
+    );
+
+    routeData = routeData.filter(
+      item => item.metadata &&
+        item.metadata.annotations &&
+        Object.keys(item.metadata.annotations).length !== 0
     );
 
     const kubernetesApps = [];
@@ -47,13 +74,32 @@ const useKubernetes = async (apps) => {
       }
     }
 
+    for (const item of routeData) {
+      const annotations = item.metadata.annotations || {};
+
+      if (/^app/.test(annotations['flame.pawelmalak/type'])) {
+        if (item.spec && item.spec.hostnames) {
+          item.spec.hostnames.forEach(hostname => {
+            kubernetesApps.push({
+              name: annotations['flame.pawelmalak/name'] || item.metadata.name,
+              url: annotations['flame.pawelmalak/url'] || hostname,
+              icon: annotations['flame.pawelmalak/icon'] || 'kubernetes',
+              type: item.routeType.toUpperCase()
+            });
+          });
+        }
+      }
+    }
+
+    const uniqueApps = Array.from(new Set(kubernetesApps.map(app => JSON.stringify(app)))).map(item => JSON.parse(item));
+
     if (unpinStoppedApps) {
       for (const app of apps) {
         await app.update({ isPinned: false });
       }
     }
 
-    for (const item of kubernetesApps) {
+    for (const item of uniqueApps) {
       if (apps.some((app) => app.name === item.name)) {
         const app = apps.find((a) => a.name === item.name);
         await app.update({ ...item, isPinned: true });

--- a/controllers/apps/docker/useKubernetes.js
+++ b/controllers/apps/docker/useKubernetes.js
@@ -7,6 +7,7 @@ const loadConfig = require('../../../utils/loadConfig');
 
 const gatewayRoutes = [
   { type: 'httproutes', version: 'v1' },
+  { type: 'httproutes', version: 'v1beta1' },
   { type: 'tcproutes', version: 'v1alpha2' },
    { type: 'grpcroutes', version: 'v1alpha2' },
    { type: 'tlsroutes', version: 'v1alpha2' },

--- a/k8s/base/rbac.yaml
+++ b/k8s/base/rbac.yaml
@@ -12,6 +12,9 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["tcproutes","httproutes","grpcroutes","tlsroutes","udproutes"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR introduces updates to the Kubernetes gateway route handling and enhances RBAC configurations to ensure proper API access permissions.

Open Issue: #452

Modified Files:
- `useKubernetes.js`
- `rbac.yaml`

Details:
- useKubernetes.js:
  - Implemented handling for multiple gateway route types in Kubernetes.
  - Added logic to utilize the `flame.pawelmalak/type` annotation to filter and surface relevant routes to the application.
- rbac.yaml:
  - Updated RBAC settings to include necessary `apiGroups`, `resources`, and `verbs`. This ensures the Flame application has the appropriate permissions to access the required Kubernetes API endpoints.

These changes aim to enhance the application's functionality and security by leveraging Kubernetes' native capabilities for managing access and routing.